### PR TITLE
Fix formatting of argument declaration with array type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
+name = "autocfg"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+
+[[package]]
 name = "bitflags"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,6 +158,7 @@ dependencies = [
  "clang",
  "clap",
  "regex",
+ "serial_test",
  "tempfile",
 ]
 
@@ -170,6 +177,83 @@ name = "fastrand"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+
+[[package]]
+name = "futures"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+
+[[package]]
+name = "futures-task"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+
+[[package]]
+name = "futures-util"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
 
 [[package]]
 name = "glob"
@@ -202,10 +286,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+
+[[package]]
 name = "memchr"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+
+[[package]]
+name = "once_cell"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "proc-macro2"
@@ -223,6 +364,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -266,6 +416,67 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys",
 ]
+
+[[package]]
+name = "scc"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ad2bbb0ae5100a07b7a6f2ed7ab5fd0045551a4c507989b7a620046ea3efdc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84345e4c9bd703274a082fb80caaa99b7612be48dfaa1dd9266577ec412309d"
+
+[[package]]
+name = "serial_test"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b4b487fe2acf240a021cf57c6b2b4903b1e78ca0ecd862a71b71d2a51fed77d"
+dependencies = [
+ "futures",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82fe9db325bcef1fbcde82e078a5cc4efdf787e96b3b9cf45b50b529f2083d67"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ clang = "2"
 regex = "1"
 
 [dev-dependencies]
+serial_test = "3"
 tempfile = "3"
 
 [[bin]]

--- a/fixtures/array.h
+++ b/fixtures/array.h
@@ -1,0 +1,3 @@
+#include <stddef.h>
+
+int compress (unsigned char buffer[], size_t size);

--- a/fixtures/out/array.c
+++ b/fixtures/out/array.c
@@ -1,0 +1,177 @@
+/*
+ * Copying and distribution of this file, with or without modification,
+ * are permitted in any medium without royalty provided the copyright
+ * notice and this notice are preserved.  This file is offered as-is,
+ * without any warranty.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "array.h"
+
+#if defined(ARRAY_ENABLE_DLOPEN) && ARRAY_ENABLE_DLOPEN
+
+#include <assert.h>
+#include <dlfcn.h>
+#include <errno.h>
+#include <stdlib.h>
+
+/* If ARRAY_SONAME is defined, dlopen handle can be automatically
+ * set; otherwise, the caller needs to call
+ * array_ensure_library with soname determined at run time.
+ */
+#ifdef ARRAY_SONAME
+
+static void
+ensure_library (void)
+{
+  if (array_ensure_library (ARRAY_SONAME, RTLD_LAZY | RTLD_LOCAL) < 0)
+    abort ();
+}
+
+#if defined(ARRAY_ENABLE_PTHREAD) && ARRAY_ENABLE_PTHREAD
+#include <pthread.h>
+
+static pthread_once_t dlopen_once = PTHREAD_ONCE_INIT;
+
+#define ENSURE_LIBRARY pthread_once(&dlopen_once, ensure_library)
+
+#else /* ARRAY_ENABLE_PTHREAD */
+
+#define ENSURE_LIBRARY do {	    \
+    if (!array_dlhandle) \
+      ensure_library();		    \
+  } while (0)
+
+#endif /* !ARRAY_ENABLE_PTHREAD */
+
+#else /* ARRAY_SONAME */
+
+#define ENSURE_LIBRARY do {} while (0)
+
+#endif /* !ARRAY_SONAME */
+
+static void *array_dlhandle;
+
+/* Define redirection symbols */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-macros"
+
+#if (2 <= __GNUC__ || (4 <= __clang_major__))
+#define FUNC(ret, name, args, cargs)			\
+  static __typeof__(name)(*array_sym_##name);
+#else
+#define FUNC(ret, name, args, cargs)		\
+  static ret(*array_sym_##name)args;
+#endif
+#define VOID_FUNC FUNC
+#include "arrayfuncs.h"
+#undef VOID_FUNC
+#undef FUNC
+
+#pragma GCC diagnostic pop
+
+/* Define redirection wrapper functions */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-macros"
+
+#define FUNC(ret, name, args, cargs)        \
+ret array_func_##name args           \
+{					    \
+  ENSURE_LIBRARY;			    \
+  assert (array_sym_##name);	    \
+  return array_sym_##name cargs;	    \
+}
+#define VOID_FUNC(ret, name, args, cargs)   \
+ret array_func_##name args           \
+{					    \
+  ENSURE_LIBRARY;			    \
+  assert (array_sym_##name);	    \
+  array_sym_##name cargs;		    \
+}
+#include "arrayfuncs.h"
+#undef VOID_FUNC
+#undef FUNC
+
+#pragma GCC diagnostic pop
+
+static int
+ensure_symbol (const char *name, void **symp)
+{
+  if (!*symp)
+    {
+      void *sym = dlsym (array_dlhandle, name);
+      if (!sym)
+	return -errno;
+      *symp = sym;
+    }
+  return 0;
+}
+
+int
+array_ensure_library (const char *soname, int flags)
+{
+  int err;
+
+  if (!array_dlhandle)
+    {
+      array_dlhandle = dlopen (soname, flags);
+      if (!array_dlhandle)
+	return -errno;
+    }
+
+#define ENSURE_SYMBOL(name)					\
+  ensure_symbol(#name, (void **)&array_sym_##name)
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-macros"
+
+#define FUNC(ret, name, args, cargs)	\
+  err = ENSURE_SYMBOL(name);		\
+  if (err < 0)				\
+    return err;
+#define VOID_FUNC FUNC
+#include "arrayfuncs.h"
+#undef VOID_FUNC
+#undef FUNC
+
+#pragma GCC diagnostic pop
+
+#undef ENSURE_SYMBOL
+  return 0;
+}
+
+void
+array_unload_library (void)
+{
+  if (array_dlhandle)
+    dlclose (array_dlhandle);
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-macros"
+
+#define FUNC(ret, name, args, cargs)		\
+  array_sym_##name = NULL;
+#define VOID_FUNC FUNC
+#include "arrayfuncs.h"
+#undef VOID_FUNC
+#undef FUNC
+
+#pragma GCC diagnostic pop
+
+#undef RESET_SYMBOL
+}
+
+#else /* ARRAY_ENABLE_DLOPEN */
+
+int
+array_ensure_library (const char *soname, int flags)
+{
+  (void) soname;
+  (void) flags;
+  return 0;
+}
+
+#endif /* !ARRAY_ENABLE_DLOPEN */

--- a/fixtures/out/array.h
+++ b/fixtures/out/array.h
@@ -1,0 +1,47 @@
+/*
+ * Copying and distribution of this file, with or without modification,
+ * are permitted in any medium without royalty provided the copyright
+ * notice and this notice are preserved.  This file is offered as-is,
+ * without any warranty.
+ */
+
+#ifndef ARRAY_H_
+#define ARRAY_H_
+
+
+
+#if defined(ARRAY_ENABLE_DLOPEN) && ARRAY_ENABLE_DLOPEN
+
+#define FUNC(ret, name, args, cargs)		\
+  ret array_func_##name args;
+#define VOID_FUNC FUNC
+#include "arrayfuncs.h"
+#undef VOID_FUNC
+#undef FUNC
+
+#define ARRAY_FUNC(name) array_func_##name
+
+#else
+
+#define ARRAY_FUNC(name) name
+
+#endif /* ARRAY_ENABLE_DLOPEN */
+
+/* Ensure SONAME to be loaded with dlopen FLAGS, and all the necessary
+ * symbols are resolved.
+ *
+ * Returns 0 on success; negative error code otherwise.
+ *
+ * Note that this function is NOT thread-safe; when calling it from
+ * multi-threaded programs, protect it with a locking mechanism.
+ */
+int array_ensure_library (const char *soname, int flags);
+
+/* Unload library and reset symbols.
+ *
+ * Note that this function is NOT thread-safe; when calling it from
+ * multi-threaded programs, protect it with a locking mechanism.
+ */
+void array_unload_library (void);
+
+#endif /* ARRAY_H_ */

--- a/fixtures/out/arrayfuncs.h
+++ b/fixtures/out/arrayfuncs.h
@@ -1,0 +1,6 @@
+/*
+ * This file was automatically generated from array.h,
+ * which is covered by the following license:
+ * TODO: INSERT LICENSE
+ */
+FUNC(int, compress, (unsigned char buffer[], int size), (buffer, size))

--- a/fixtures/out/cgwrap.c
+++ b/fixtures/out/cgwrap.c
@@ -5,6 +5,10 @@
  * without any warranty.
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include "cgwrap.h"
 
 #if defined(CGWRAP_ENABLE_DLOPEN) && CGWRAP_ENABLE_DLOPEN
@@ -52,6 +56,9 @@ static pthread_once_t dlopen_once = PTHREAD_ONCE_INIT;
 static void *cgwrap_dlhandle;
 
 /* Define redirection symbols */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-macros"
+
 #if (2 <= __GNUC__ || (4 <= __clang_major__))
 #define FUNC(ret, name, args, cargs)			\
   static __typeof__(name)(*cgwrap_sym_##name);
@@ -64,7 +71,12 @@ static void *cgwrap_dlhandle;
 #undef VOID_FUNC
 #undef FUNC
 
+#pragma GCC diagnostic pop
+
 /* Define redirection wrapper functions */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-macros"
+
 #define FUNC(ret, name, args, cargs)        \
 ret cgwrap_func_##name args           \
 {					    \
@@ -83,6 +95,8 @@ ret cgwrap_func_##name args           \
 #undef VOID_FUNC
 #undef FUNC
 
+#pragma GCC diagnostic pop
+
 static int
 ensure_symbol (const char *name, void **symp)
 {
@@ -93,6 +107,7 @@ ensure_symbol (const char *name, void **symp)
 	return -errno;
       *symp = sym;
     }
+  return 0;
 }
 
 int
@@ -109,6 +124,10 @@ cgwrap_ensure_library (const char *soname, int flags)
 
 #define ENSURE_SYMBOL(name)					\
   ensure_symbol(#name, (void **)&cgwrap_sym_##name)
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-macros"
+
 #define FUNC(ret, name, args, cargs)	\
   err = ENSURE_SYMBOL(name);		\
   if (err < 0)				\
@@ -117,6 +136,9 @@ cgwrap_ensure_library (const char *soname, int flags)
 #include "cgwrapfuncs.h"
 #undef VOID_FUNC
 #undef FUNC
+
+#pragma GCC diagnostic pop
+
 #undef ENSURE_SYMBOL
   return 0;
 }
@@ -127,12 +149,18 @@ cgwrap_unload_library (void)
   if (cgwrap_dlhandle)
     dlclose (cgwrap_dlhandle);
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-macros"
+
 #define FUNC(ret, name, args, cargs)		\
   cgwrap_sym_##name = NULL;
 #define VOID_FUNC FUNC
 #include "cgwrapfuncs.h"
 #undef VOID_FUNC
 #undef FUNC
+
+#pragma GCC diagnostic pop
+
 #undef RESET_SYMBOL
 }
 

--- a/templates/loader.c.in
+++ b/templates/loader.c.in
@@ -5,6 +5,10 @@
  * without any warranty.
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include "@LOADER_H@"
 
 #if defined(@ENABLE_DLOPEN@) && @ENABLE_DLOPEN@
@@ -52,6 +56,9 @@ static pthread_once_t dlopen_once = PTHREAD_ONCE_INIT;
 static void *@LIBRARY_PREFIX@_dlhandle;
 
 /* Define redirection symbols */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-macros"
+
 #if (2 <= __GNUC__ || (4 <= __clang_major__))
 #define FUNC(ret, name, args, cargs)			\
   static __typeof__(name)(*@SYMBOL_PREFIX@_##name);
@@ -64,7 +71,12 @@ static void *@LIBRARY_PREFIX@_dlhandle;
 #undef VOID_FUNC
 #undef FUNC
 
+#pragma GCC diagnostic pop
+
 /* Define redirection wrapper functions */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-macros"
+
 #define FUNC(ret, name, args, cargs)        \
 ret @FUNCTION_PREFIX@_##name args           \
 {					    \
@@ -83,6 +95,8 @@ ret @FUNCTION_PREFIX@_##name args           \
 #undef VOID_FUNC
 #undef FUNC
 
+#pragma GCC diagnostic pop
+
 static int
 ensure_symbol (const char *name, void **symp)
 {
@@ -93,6 +107,7 @@ ensure_symbol (const char *name, void **symp)
 	return -errno;
       *symp = sym;
     }
+  return 0;
 }
 
 int
@@ -109,6 +124,10 @@ int
 
 #define ENSURE_SYMBOL(name)					\
   ensure_symbol(#name, (void **)&@SYMBOL_PREFIX@_##name)
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-macros"
+
 #define FUNC(ret, name, args, cargs)	\
   err = ENSURE_SYMBOL(name);		\
   if (err < 0)				\
@@ -117,6 +136,9 @@ int
 #include "@FUNCTIONS_H@"
 #undef VOID_FUNC
 #undef FUNC
+
+#pragma GCC diagnostic pop
+
 #undef ENSURE_SYMBOL
   return 0;
 }
@@ -127,12 +149,18 @@ void
   if (@LIBRARY_PREFIX@_dlhandle)
     dlclose (@LIBRARY_PREFIX@_dlhandle);
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-macros"
+
 #define FUNC(ret, name, args, cargs)		\
   @SYMBOL_PREFIX@_##name = NULL;
 #define VOID_FUNC FUNC
 #include "@FUNCTIONS_H@"
 #undef VOID_FUNC
 #undef FUNC
+
+#pragma GCC diagnostic pop
+
 #undef RESET_SYMBOL
 }
 


### PR DESCRIPTION
Previously, an argument with a type in the form of `elemen_type[]` was
formatted as "elemen_type[] name". This is now printed as "elemen_type
name[]".