### PR TITLE
Infer Clang resource directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,6 +156,7 @@ version = "0.3.5"
 dependencies = [
  "anyhow",
  "clang",
+ "clang-sys",
  "clap",
  "regex",
  "serial_test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ authors = ["Daiki Ueno"]
 anyhow = "1"
 clap = { version = "4", features=["derive"] }
 clang = { version = "2", features=["clang_7_0"] }
+clang-sys = { version = "1", features=["clang_7_0"] }
 regex = "1"
 
 [dev-dependencies]

--- a/fixtures/out/arrayfuncs.h
+++ b/fixtures/out/arrayfuncs.h
@@ -3,4 +3,4 @@
  * which is covered by the following license:
  * TODO: INSERT LICENSE
  */
-FUNC(int, compress, (unsigned char buffer[], int size), (buffer, size))
+FUNC(int, compress, (unsigned char buffer[], size_t size), (buffer, size))


### PR DESCRIPTION
clang-sys has a feature to access Clang installation through the clang_sys::support module, which allows us to omit --clang-resource-dir argument from the command-line.